### PR TITLE
Allow configuring spec base directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rails Go to Spec
 ================
 
-A Sublime Text 3 plug-in. From a .rb file this plug-in will open the relevant spec. If the spec doesn't exist it asks if it should be created. 
+A Sublime Text 3 plug-in. From a .rb file this plug-in will open the relevant spec. If the spec doesn't exist it asks if it should be created.
 
 Only supports _spec.rb files at the moment.
 
@@ -12,6 +12,9 @@ Using Sublime Package Control
 http://wbond.net/sublime_packages/package_control
 
 Install rails_go_to_spec
+
+By default, specs are assumed to live in "/spec", but if you have a nonstandard
+location, you can override with the "go_to_spec_directory" setting in your preferences.
 
 Usage
 -----

--- a/rails_go_to_spec.py
+++ b/rails_go_to_spec.py
@@ -17,7 +17,8 @@ class RailsGoToSpecCommand(sublime_plugin.WindowCommand):
 		if os.name == 'nt':
 			current_file = current_file.replace('\\', '/')
 
-		related_files = RailsGoToSpec.resolver.Resolver().run(current_file)
+		spec_base = view.settings().get('go_to_spec_directory') or 'spec'
+		related_files = RailsGoToSpec.resolver.Resolver().run(current_file, spec_base)
 
 		# add the root dir to all files
 		for ix, file in enumerate(related_files):

--- a/resolver.py
+++ b/resolver.py
@@ -2,16 +2,16 @@ import re
 
 class Resolver:
 
-	def run(self, file):
+	def run(self, file, spec_base='spec'):
 		if self.is_spec(file):
-			return self.get_source(file)
+			return self.get_source(file, spec_base)
 		else:
-			return self.get_spec(file)
+			return self.get_spec(file, spec_base)
 
 	def is_spec(self, file):
 		return file.find('_spec.rb') != -1
 
-	def get_source(self, file):
+	def get_source(self, file, spec_base='spec'):
 		# find erb, haml
 		match = re.search(r'(.erb|.haml|.slim|.jbuilder)_spec.rb$', file)
 		related = []
@@ -26,17 +26,17 @@ class Resolver:
 			# e.g. foo.rb -> foo_spec.rb
 			file = re.sub(r'\_spec.rb$', '.rb', file)
 
-		if file.find('/spec/lib/') > -1:
+		if file.find('/' + spec_base + '/lib/') > -1:
 			# file in lib
-			related.append(re.sub(r'/spec/lib/', '/lib/', file))
+			related.append(re.sub(r'/' + spec_base + '/lib/', '/lib/', file))
 		else:
-			related.append(re.sub(r'/spec/', '/app/', file, 1))
-			related.append(re.sub(r'/spec/', '/', file, 1))
+			related.append(re.sub(r'/' + spec_base + '/', '/app/', file, 1))
+			related.append(re.sub(r'/' + spec_base + '/', '/', file, 1))
 
 		return related
 
 
-	def get_spec(self, file):
+	def get_spec(self, file, spec_base='spec'):
 		# find erb, haml
 		match = re.search(r'erb$|haml$|slim$|jbuilder$', file)
 		related = []
@@ -49,10 +49,10 @@ class Resolver:
 			file = re.sub(r'\.rb$', '_spec.rb', file)
 
 		if file.find('/lib/') > -1:
-			related.append(re.sub(r'/lib/', '/spec/lib/', file))
+			related.append(re.sub(r'/lib/', '/' + spec_base + '/lib/', file))
 		elif file.find('/app/') > -1:
-			related.append(re.sub(r'/app/', '/spec/', file, 1))
+			related.append(re.sub(r'/app/', '/' + spec_base + '/', file, 1))
 		else:
-			related.append('/spec' + file)
+			related.append('/' + spec_base + file)
 
 		return related


### PR DESCRIPTION
My specific use case is that all specs were put in "spec/test", e.g. "spec/tests/models/thing_spec.rb"