### PR TITLE
Fix error on import resolver in resolver_test.py

### DIFF
--- a/resolver_test.py
+++ b/resolver_test.py
@@ -2,7 +2,7 @@
 # python resolver_test.py
 
 import unittest
-from resolver import *
+from .resolver import *
 
 class ResolverTest(unittest.TestCase):
 


### PR DESCRIPTION
Fix #18

An alternative fix would be `from RailsToGoSpec.resolver import *`