### PR TITLE
Fix path when running test suite locally.

### DIFF
--- a/resolver_test.py
+++ b/resolver_test.py
@@ -2,7 +2,11 @@
 # python resolver_test.py
 
 import unittest
-from .resolver import *
+try:
+	from .resolver import *
+except ImportError:
+	from resolver import *
+
 
 class ResolverTest(unittest.TestCase):
 


### PR DESCRIPTION
The fix I suggested in https://github.com/sporto/rails_go_to_spec/pull/19, turns out to break running the test suite locally. 
This new fix should allow running the test suite both locally and from inside SublimeText.